### PR TITLE
prefetch related fields to save on page load

### DIFF
--- a/rbhl/patient_lists.py
+++ b/rbhl/patient_lists.py
@@ -85,6 +85,10 @@ class ActivePatients(StaticTableList):
         """
         return Episode.objects.filter(
             cliniclog__active=True
+        ).prefetch_related(
+            "cliniclog_set"
+        ).prefetch_related(
+            "patient__demographics_set"
         ).order_by(
             "cliniclog__clinic_date"
         )

--- a/rbhl/templates/patient_lists/active_patients.html
+++ b/rbhl/templates/patient_lists/active_patients.html
@@ -9,9 +9,9 @@
     </tr>
     {% for episode in object_list %}
       <tr onclick=window.location="{{ episode.get_absolute_url }}" class="pointer">
-          <td>{{ episode.patient.demographics_set.get.hospital_number }}</td>
-          <td>{{ episode.patient.demographics_set.get.name }}</td>
-          {% with cliniclog=episode.cliniclog_set.get %}
+          <td>{{ episode.patient.demographics_set.all.0.hospital_number }}</td>
+          <td>{{ episode.patient.demographics_set.all.0.name }}</td>
+          {% with cliniclog=episode.cliniclog_set.all.0 %}
           <td>
             {% if cliniclog.days_since_first_attended %}
               {{ cliniclog.days_since_first_attended }}


### PR DESCRIPTION
prefetches related fields.. some numbers

at present we load recent prod data in 1.1 seconds
if we prefetch the clinical data this goes down to 0.814 seconds
if we prefetch demographics as well we go down to 0.468 seconds

I think if we're doing server side sorting, this is a nice thing to do.