### PR TITLE
The working day is _still_ to vague to be seen on the projector, this…

### DIFF
--- a/rbhl/static/js/rbhl/directives.js
+++ b/rbhl/static/js/rbhl/directives.js
@@ -260,9 +260,9 @@ directives.directive("peakFlowGraph", function($timeout, displayDateFilter) {
             }
           });
 
-          // the default fill (0.1) opacity provided by d3 makes it so light you can't see
-          // workdays on the projector
-          d3.select(element).selectAll(".c3-region.workingday rect").style("fill-opacity", "0.2");
+          // // the default fill (0.1) opacity provided by d3 makes it so light you can't see
+          // // workdays on the projector
+          d3.select(element).selectAll(".c3-region.workingday rect").style("fill-opacity", "0.3");
         };
 
         let calculateGraphAxisAndHeight = function(columns){


### PR DESCRIPTION
… bumps it by another 0.1

was 
![Screen Shot 2019-11-22 at 12 10 42](https://user-images.githubusercontent.com/2175455/69424691-2a1f5600-0d21-11ea-8e58-f16209e9179e.png)

After this change
![Screen Shot 2019-11-22 at 12 10 46](https://user-images.githubusercontent.com/2175455/69424707-34d9eb00-0d21-11ea-8f9f-0e4784df8778.png)

If we wanted to bump it more (I think this is too much, but I'm not using a projector...)
![Screen Shot 2019-11-22 at 12 10 50](https://user-images.githubusercontent.com/2175455/69424724-41f6da00-0d21-11ea-8f39-771ad7089e59.png)

