### PR TITLE
The user has decided that the abbreviation for Peak Expiritarory flow…

### DIFF
--- a/rbhl/templates/partials/peak_flow_graph.html
+++ b/rbhl/templates/partials/peak_flow_graph.html
@@ -25,7 +25,7 @@
   </div>
   <div class="col-md-4">
         <strong>
-          Predicted PEF:
+          Predicted PF:
         </strong>
         &nbsp;
         [[ peakFlowTrial.pef_mean ]]

--- a/rbhl/templates/pathway/base/rbhl_graph_base.html
+++ b/rbhl/templates/pathway/base/rbhl_graph_base.html
@@ -27,7 +27,7 @@
             </td>
             <td>
               <strong>
-                Predicted PEF:
+                Predicted PF:
               </strong>
               &nbsp;
               [[ peakFlowTrial.pef_mean ]]


### PR DESCRIPTION
… is PF rather than PEF (we were using both so consistency++ now)