### PR TITLE
Their reference number in display and fix a bug where the pencil edit was not showing

### DIFF
--- a/rbhl/templates/records/referral.html
+++ b/rbhl/templates/records/referral.html
@@ -12,12 +12,24 @@
   <div class="col-md-6">
     <div class="row">
       <div class="col-md-5">
-          <b>Referrer name:</b>
-      </div>
-      <div class="col-md-7 edit-item-padding" ng-show="item.referrer_name">
-        [[ item.referrer_name ]]
-        <span ng-show="item.reference_number">([[ item.reference_number ]])</span>
+        {% comment %}
+        The field is Referrer name if there is a referrer name and it
+        displays referrer name (reference number).
 
+        If there is no referrer name but there is a reference number then it
+        changes the name to reference number and displays the reference number
+        {% endcomment %}
+        <span ng-if="!item.referrer_name && item.reference_number">
+          <b>Their reference number:</b>
+        </span>
+        <span ng-if="item.referrer_name || !item.reference_number">
+          <b>Referrer name:</b>
+        </span>
+      </div>
+      <div class="col-md-7 edit-item-padding">
+        [[ item.referrer_name ]]
+        <span ng-show="item.reference_number && item.referrer_name">([[ item.reference_number ]])</span>
+        <span ng-show="!item.referrer_name">[[ item.reference_number ]]</span>
         <i class="fa fa-pencil edit pointer edit-item" ng-click="episode.recordEditor.editItem('referral', item)"></i>
       </div>
     </div>


### PR DESCRIPTION
So there was a bug that if there was no referrer name it did not show the pencil. So this fixes that. 
We were showing the referrer number in brackets but if there was no referrer name again this looked odd... So with this there are 3 states.

![Screen Shot 2021-01-26 at 15 47 26](https://user-images.githubusercontent.com/2175455/105868483-20147980-5fee-11eb-83d0-ae13ade1c7d8.png)
![Screen Shot 2021-01-26 at 15 46 48](https://user-images.githubusercontent.com/2175455/105868499-230f6a00-5fee-11eb-846e-544b9a322aa5.png)
![Screen Shot 2021-01-26 at 15 47 06](https://user-images.githubusercontent.com/2175455/105868514-286cb480-5fee-11eb-8c51-e5fd28bfbc63.png)
