### PR TITLE
Bumps the opal version to v0.21.0

### DIFF
--- a/deployment/group_vars/all
+++ b/deployment/group_vars/all
@@ -16,7 +16,7 @@ DB_PASSWORD: !vault |
 PROJECT_PATH: /usr/lib/ohc/rbhl
 BACKUPS_DIR: /usr/lib/ohc/var
 GIT_REPO: https://github.com/openhealthcare/rbhl
-GIT_BRANCH: v1.19
+GIT_BRANCH: v1.23
 LOG_DIR: /usr/lib/ohc/log
 PROJECT_NAME: rbhl
 SECRET_KEY: !vault |

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,14 +7,14 @@ psycopg2==2.8.6
 dj-static==0.0.6
 django-reversion==3.0.8
 django-compressor==2.4
-django-celery==3.2.2
-celery==3.1.25
+django-celery-results==2.0.0
+celery==5.0.2
 django_otp==0.5.1
 django-two-factor-auth==1.8.0
 django-formtools==2.1
 flake8==3.8.4
 boto3==1.9.178
-opal==0.20.0
+opal==0.21.0
 python-dateutil==2.8.1
 holidays==0.10.5.2
 more-itertools==8.7.0


### PR DESCRIPTION
We don't actually use celery at this time, but either way, lets bump it.