### PR TITLE
UNTESTED: Don't even send direct IP address traffic to the application

### DIFF
--- a/deployment/templates/nginx_site.conf.jinja2
+++ b/deployment/templates/nginx_site.conf.jinja2
@@ -29,6 +29,12 @@ server {
 
     access_log {{ LOG_DIR }}/nginx.log timed_combined;
 
+    # https://stackoverflow.com/questions/49420755/trying-to-prevent-direct-ip-access-nginx-ssl
+    # block direct IP access
+    if ($http_host != $server_name) {
+        return 444;
+    }
+
    location /static {
         alias {{ PROJECT_PATH }}/static;
     }


### PR DESCRIPTION
I think this prevents us getting Django admin error emails from people who've set up web scanners to hit every addressable IP.