### PR TITLE
Reduce transaction scope

### DIFF
--- a/rbhl/management/commands/generate_clinic_facts.py
+++ b/rbhl/management/commands/generate_clinic_facts.py
@@ -11,7 +11,7 @@ logger = logging.getLogger('commands')
 
 
 class Command(BaseCommand):
-    def get_five_year_episodes(cls):
+    def get_five_year_episodes(self):
         today = datetime.date.today()
         if today.month > 9:
             five_year_range = (


### PR DESCRIPTION
This is probably more code than expected...

Things to note...

1. In https://github.com/openhealthcare/rbhl/commit/d2da738e45a8fce97e288253797ba75e5f8219b5 we removed the five year mean to diagnosis. A lot of this code dealt with that and was still hanging about (although not actually saving a fact). So this removes that code.
2. We were keeping one fact about and deleting the other. It doesn't actually matter as the calling code always got the latest fact but we may as well delete both to keep it consistent.



