### PR TITLE
Bug fix rows

### DIFF
--- a/plugins/lab/tests/test_models.py
+++ b/plugins/lab/tests/test_models.py
@@ -51,7 +51,6 @@ class BloodsTestCase(OpalTestCase):
             "consistency_token": "",
             "created": None,
             "created_by_id": None,
-            'date_dna_extracted': None,
             'exposure': '',
             'freezer': None,
             "id": bloods.id ,

--- a/plugins/lab/views.py
+++ b/plugins/lab/views.py
@@ -561,7 +561,7 @@ class LabMonthActivity(AbstractLabStatsPage):
                 row[f"Precipitin {idx}"] = result.precipitin
                 row[f"IgG {idx}"] = result.igg
                 row[f"IgG Class {idx}"] = result.iggclass
-                rows.append(row)
+            rows.append(row)
         return rows
 
     def pad_rows(self, list_of_dicts):


### PR DESCRIPTION
In 1.33 push was released in commit [a05c63b4adfd60bd47e36dd79bebb0c96dd0e2fc](https://github.com/openhealthcare/rbhl/commit/a05c63b4adfd60bd47e36dd79bebb0c96dd0e2fc) that shifted the rows.append indent out by a tab. This changed the structure of the download adding rows to the bottom rather than width wise.